### PR TITLE
add checks for hasOwnProperty and used forEach where useful

### DIFF
--- a/lib/js/emojione.js
+++ b/lib/js/emojione.js
@@ -343,9 +343,10 @@
     // needs to be improved into one big replacement instead, for performance reasons
     ns.toShort = function(str) { // this is really just unicodeToShortname() but I opted for the shorthand name to match toImage()
         for (var shortcode in ns.emojioneList) {
-            for (var ukey in ns.emojioneList[shortcode]) {
-                var unicode = ns.emojioneList[shortcode][ukey].toUpperCase();
-                str = ns.replaceAll(str,ns.convert(unicode),shortcode);
+            if (ns.emojioneList.hasOwnProperty(shortcode)) {
+                ns.emojioneList[shortcode].forEach(function(unicode) {
+                    str = ns.replaceAll(str,ns.convert(unicode.toUpperCase()),shortcode);
+                });
             }
         }
         return str;
@@ -402,8 +403,10 @@
     ns.mapShortToUnicode = function() {
         var new_obj = {};
         for (var shortname in ns.emojioneList) {
-            for (var ukey in ns.emojioneList[shortname]) {
-                new_obj[ns.emojioneList[shortname][ukey].toUpperCase()] = shortname;
+            if (ns.emojioneList.hasOwnProperty(shortname)) {
+                ns.emojioneList[shortname].forEach(function(unicode) {
+                    new_obj[unicode.toUpperCase()] = shortname;
+                });
             }
         }
         return new_obj;

--- a/lib/validate.yml
+++ b/lib/validate.yml
@@ -36,10 +36,10 @@ tests:
   toImage:
     - description: "single character shortname conversion"
       text: ":snail:"
-      expected: "<img class=\"emojione\" alt=\"🐌\" src=\"//cdn.jsdelivr.net/emojione/assets/png/1F40C.png\"/>"
+      expected: "<img class=\"emojione\" alt=\"🐌\" src=\"//cdn.jsdelivr.net/emojione/assets/png/1F40C.png?v=1.2.4\"/>"
     - description: "shortname shares a colon"
       text: ":invalid:snail:"
       expected: ":invalid:snail:"
     - description: "single unicode character conversion"
       text: "🐌"
-      expected: "<img class=\"emojione\" alt=\"🐌\" src=\"//cdn.jsdelivr.net/emojione/assets/png/1F40C.png\"/>"
+      expected: "<img class=\"emojione\" alt=\"🐌\" src=\"//cdn.jsdelivr.net/emojione/assets/png/1F40C.png?v=1.2.4\"/>"


### PR DESCRIPTION
when Object.prototype is modified (or Array.prototype, for that matter), we can no longer iterate over the keys (or elements, respectively) using `for (var ... in ...)`. Added a hasOwnProperty check for object key iteration, and used `.forEach` for array element iteration instead.
